### PR TITLE
feat transfers: handle transfer events

### DIFF
--- a/app/Actions/Account/Create.php
+++ b/app/Actions/Account/Create.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Account;
 
 use App\Models\Account;
+use DB;
 
 class Create
 {
@@ -26,13 +27,23 @@ class Create
 
     public function execute(): Account
     {
-        $account = new Account();
+        try {
+            DB::beginTransaction();
 
-        $account->id      = $this->id;
-        $account->balance = $this->balance;
+            $account = new Account();
 
-        $account->save();
+            $account->id      = $this->id;
+            $account->balance = $this->balance;
 
-        return $account;
+            $account->save();
+
+            DB::commit();
+
+            return $account;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+
+            throw $e;
+        }
     }
 }

--- a/app/Actions/Account/Deposit.php
+++ b/app/Actions/Account/Deposit.php
@@ -32,8 +32,9 @@ class Deposit
 
     private function increaseAccountBalance(): void
     {
-        $this->account->balance += $this->amount;
-        $this->account->save();
+        $this->account
+            ->increaseBalance($this->amount)
+            ->save();
     }
 
     private function saveTransaction(): Transaction

--- a/app/Actions/Account/Transfer.php
+++ b/app/Actions/Account/Transfer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Actions\Account;
+
+use App\Events\Account\TransferReceived;
+use App\Events\Account\TransferSended;
+use App\Models\Account;
+use App\Models\Transaction;
+use DB;
+
+class Transfer
+{
+    protected Account $originAccount;
+
+    protected Account $destinationAccount;
+
+    protected int $amount;
+
+    public function setOriginAccount(Account $originAccount): self
+    {
+        $this->originAccount = $originAccount;
+
+        return $this;
+    }
+
+    public function setDestinationAccount(Account $destinationAccount): self
+    {
+        $this->destinationAccount = $destinationAccount;
+
+        return $this;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function execute(): Transaction
+    {
+        try {
+            DB::beginTransaction();
+
+            $this->originAccount
+                ->decreaseBalance($this->amount)
+                ->save();
+
+            $this->destinationAccount
+                ->increaseBalance($this->amount)
+                ->save();
+
+            $transaction = $this->createTransaction();
+
+            event(new TransferReceived($this->destinationAccount, $transaction));
+
+            event(new TransferSended($this->originAccount, $transaction));
+
+            DB::commit();
+
+            return $transaction;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+
+            throw $e;
+        }
+    }
+
+    protected function createTransaction(): Transaction
+    {
+        $transaction = new Transaction();
+
+        $transaction->type                            = Transaction::TYPES['transfer'];
+        $transaction->amount                          = $this->amount;
+        $transaction->origin_internal_account_id      = $this->originAccount->id;
+        $transaction->destination_internal_account_id = $this->destinationAccount->id;
+
+        $transaction->save();
+
+        return $transaction;
+    }
+}

--- a/app/Actions/Account/Withdraw.php
+++ b/app/Actions/Account/Withdraw.php
@@ -43,8 +43,9 @@ class Withdraw
 
     protected function subtractAmountFromBalance(): void
     {
-        $this->account->balance -= $this->amount;
-        $this->account->save();
+        $this->account
+            ->decreaseBalance($this->amount)
+            ->save();
     }
 
     protected function saveTransaction(): Transaction

--- a/app/Events/Account/TransferReceived.php
+++ b/app/Events/Account/TransferReceived.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Events\Account;
+
+use App\Models\Account;
+use App\Models\Transaction;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TransferReceived
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Account $account,
+        public Transaction $transaction
+    ) {
+        //
+    }
+}

--- a/app/Events/Account/TransferSended.php
+++ b/app/Events/Account/TransferSended.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Events\Account;
+
+use App\Models\Account;
+use App\Models\Transaction;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TransferSended
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Account $account,
+        public Transaction $transaction
+    ) {
+        //
+    }
+}

--- a/app/Http/Controllers/Balance/IndexController.php
+++ b/app/Http/Controllers/Balance/IndexController.php
@@ -13,7 +13,7 @@ class IndexController extends Controller
     public function __invoke(Request $request)
     {
         $data = $request->validate([
-            'account_id' => ['required', 'string'],
+            'account_id' => ['required', 'integer'],
         ]);
 
         try {

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -40,4 +40,18 @@ class Account extends Model
     {
         return $this->hasMany(Transaction::class, 'destination_internal_account_id');
     }
+
+    public function increaseBalance(int $amount): self
+    {
+        $this->balance += $amount;
+
+        return $this;
+    }
+
+    public function decreaseBalance(int $amount): self
+    {
+        $this->balance -= $amount;
+
+        return $this;
+    }
 }

--- a/tests/Feature/Balance/GetBalanceTest.php
+++ b/tests/Feature/Balance/GetBalanceTest.php
@@ -34,7 +34,7 @@ class GetBalanceTest extends TestCase
     /** @test */
     public function it_should_return_not_found_and_0_if_the_account_does_not_exists(): void
     {
-        $this->get(route('balance.index', ['account_id' => 'non-existent-account']))
+        $this->get(route('balance.index', ['account_id' => 999999]))
             ->assertStatus(404)
             ->assertSee(0);
     }

--- a/tests/Feature/Transactions/TransferTest.php
+++ b/tests/Feature/Transactions/TransferTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Events\Account\TransferReceived;
+use App\Events\Account\TransferSended;
+use App\Models\Account;
+use App\Models\Transaction;
+use Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransferTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_should_decrease_origin_and_increase_destination_account(): void
+    {
+        $originAccount = Account::factory()->create([
+            'balance' => 1000,
+        ]);
+
+        $destinationAccount = Account::factory()->create([
+            'balance' => 0,
+        ]);
+
+        $data = [
+            'type'        => Transaction::TYPES['transfer'],
+            'origin'      => $originAccount->id,
+            'destination' => $destinationAccount->id,
+            'amount'      => 100,
+        ];
+
+        $response = $this->post(route('transaction'), $data);
+
+        $response->assertStatus(201);
+
+        $response->assertExactJson([
+            'origin' => [
+                'id'      => $originAccount->id,
+                'balance' => 900,
+            ],
+            'destination' => [
+                'id'      => $destinationAccount->id,
+                'balance' => 100,
+            ],
+        ]);
+
+        $this->assertDatabaseHas('accounts', [
+            'id'      => $originAccount->id,
+            'balance' => 900,
+        ]);
+
+        $this->assertDatabaseHas('accounts', [
+            'id'      => $destinationAccount->id,
+            'balance' => 100,
+        ]);
+
+        $this->assertDatabaseHas('transactions', [
+            'type'                            => Transaction::TYPES['transfer'],
+            'origin_internal_account_id'      => $originAccount->id,
+            'destination_internal_account_id' => $destinationAccount->id,
+            'amount'                          => 100,
+        ]);
+    }
+
+    /** @test */
+    public function assert_events_are_dispatched_as_excepted(): void
+    {
+        $originAccount = Account::factory()->create([
+            'balance' => 1000,
+        ]);
+
+        $destinationAccount = Account::factory()->create([
+            'balance' => 0,
+        ]);
+
+        $data = [
+            'type'        => Transaction::TYPES['transfer'],
+            'origin'      => $originAccount->id,
+            'destination' => $destinationAccount->id,
+            'amount'      => 100,
+        ];
+
+        Event::fake([
+            TransferReceived::class,
+            TransferSended::class,
+        ]);
+
+        $response = $this->post(route('transaction'), $data);
+
+        $response->assertStatus(201);
+
+        Event::assertDispatched(TransferReceived::class, function ($event) use ($destinationAccount) {
+            return $event->account->id === $destinationAccount->id
+                && $event->transaction instanceof Transaction;
+        });
+
+        Event::assertDispatched(TransferSended::class, function (TransferSended $event) use ($originAccount) {
+            return $event->account->id === $originAccount->id
+                && $event->transaction instanceof Transaction;
+        });
+    }
+
+    /** @test */
+    public function assert_transfers_can_not_be_made_from_an_non_existing_account(): void
+    {
+        $destinationAccount = Account::factory()->create([
+            'balance' => 0,
+        ]);
+
+        $data = [
+            'type'        => Transaction::TYPES['transfer'],
+            'origin'      => 9999,
+            'destination' => $destinationAccount->id,
+            'amount'      => 100,
+        ];
+
+        $response = $this->post(route('transaction'), $data);
+
+        $response->assertStatus(404);
+
+        $response->assertSee(0);
+    }
+
+    /** @test */
+    public function assert_the_destination_account_is_created_when_a_transfer_is_made_to_an_non_existing_account(): void
+    {
+        $originAccount = Account::factory()->create([
+            'balance' => 1000,
+        ]);
+
+        $data = [
+            'type'        => Transaction::TYPES['transfer'],
+            'origin'      => $originAccount->id,
+            'destination' => 9999,
+            'amount'      => 100,
+        ];
+
+        $response = $this->post(route('transaction'), $data);
+
+        $response->assertStatus(201);
+
+        $response->assertExactJson([
+            'origin' => [
+                'id'      => $originAccount->id,
+                'balance' => 900,
+            ],
+            'destination' => [
+                'id'      => "9999",
+                'balance' => 100,
+            ],
+        ]);
+
+        $this->assertDatabaseHas('accounts', [
+            'id'      => $originAccount->id,
+            'balance' => 900,
+        ]);
+
+        $this->assertDatabaseHas('accounts', [
+            'id'      => 9999,
+            'balance' => 100,
+        ]);
+
+        $this->assertDatabaseHas('transactions', [
+            'type'                            => Transaction::TYPES['transfer'],
+            'origin_internal_account_id'      => $originAccount->id,
+            'destination_internal_account_id' => 9999,
+            'amount'                          => 100,
+        ]);
+    }
+}


### PR DESCRIPTION
transfers between an existing account and non-existing account (the account is created during the transfer)
if the origin account does not exist, returns 404 and do not performs the transfer